### PR TITLE
WifiManager: Add StaState API [1/2]

### DIFF
--- a/wifi/java/android/net/wifi/IStaStateCallback.aidl
+++ b/wifi/java/android/net/wifi/IStaStateCallback.aidl
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2020 The Potato Open Sauce Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.net.wifi;
+
+/**
+ * @hide
+ */
+oneway interface IStaStateCallback
+{
+   /**
+    * @hide
+    */
+   void onStaToBeOff();
+}

--- a/wifi/java/android/net/wifi/IWifiManager.aidl
+++ b/wifi/java/android/net/wifi/IWifiManager.aidl
@@ -33,6 +33,7 @@ import android.net.wifi.IOnWifiUsabilityStatsListener;
 import android.net.wifi.IScanResultsCallback;
 import android.net.wifi.ISoftApCallback;
 import android.net.wifi.ISuggestionConnectionStatusListener;
+import android.net.wifi.IStaStateCallback;
 import android.net.wifi.ITrafficStateCallback;
 import android.net.wifi.IWifiConnectedNetworkScorer;
 import android.net.wifi.ScanResult;
@@ -275,4 +276,8 @@ interface IWifiManager
     void setAutoWakeupEnabled(boolean enable);
 
     boolean isAutoWakeupEnabled();
+
+    void registerStaStateCallback(in IBinder binder, in IStaStateCallback callback, int callbackIdentifier);
+
+    void unregisterStaStateCallback(int callbackIdentifier);
 }

--- a/wifi/java/android/net/wifi/WifiManager.java
+++ b/wifi/java/android/net/wifi/WifiManager.java
@@ -5275,6 +5275,71 @@ public class WifiManager {
     }
 
     /**
+     * @hide
+     */
+    public interface StaStateCallback {
+        /**
+         * @hide
+         */
+        void onStaToBeOff();
+    }
+
+    /**
+     * @hide
+     */
+    private class StaStateCallbackProxy extends IStaStateCallback.Stub {
+        private final Handler mHandler;
+        private final StaStateCallback mCallback;
+
+        StaStateCallbackProxy(Looper looper, StaStateCallback callback) {
+            mHandler = new Handler(looper);
+            mCallback = callback;
+        }
+
+        @Override
+        public void onStaToBeOff() {
+            if (mVerboseLoggingEnabled) {
+                Log.v(TAG, "StaStateCallbackProxy: onStaToBeOff");
+            }
+            mHandler.post(() -> {
+                mCallback.onStaToBeOff();
+            });
+        }
+    }
+
+    /**
+     * @hide
+     */
+    public void registerStaStateCallback(@NonNull StaStateCallback callback,
+                                             @Nullable Handler handler) {
+        if (callback == null) throw new IllegalArgumentException("callback cannot be null");
+        Log.v(TAG, "registerStaStateCallback: callback=" + callback + ", handler=" + handler);
+
+        Looper looper = (handler == null) ? mContext.getMainLooper() : handler.getLooper();
+        Binder binder = new Binder();
+        try {
+            mService.registerStaStateCallback(
+                    binder, new StaStateCallbackProxy(looper, callback), callback.hashCode());
+        } catch (RemoteException e) {
+            throw e.rethrowFromSystemServer();
+        }
+    }
+
+    /**
+     * @hide
+     */
+    public void unregisterStaStateCallback(@NonNull StaStateCallback callback) {
+        if (callback == null) throw new IllegalArgumentException("callback cannot be null");
+        Log.v(TAG, "unregisterStaStateCallback: callback=" + callback);
+
+        try {
+            mService.unregisterStaStateCallback(callback.hashCode());
+        } catch (RemoteException e) {
+            throw e.rethrowFromSystemServer();
+        }
+    }
+
+    /**
      * Helper method to update the local verbose logging flag based on the verbose logging
      * level from wifi service.
      */


### PR DESCRIPTION
Wifi stastate callback functions are refrenced by mediatek ims blobs when they init to register ims-service.

test: IMS services (voLTE and voWIFI) works fine on mtk67xx (begonia) and crashes due to missing stastate callback functions is no more.

- Reversed out from miui_BEGONIAININGlobal_V11.0.2.0.QGGINXM_7e11a54a70_10.0

Change-Id: I7309906d775f45c7ea42b3324679a0f7b776a1c9